### PR TITLE
Re-enable Github releases in the release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ jobs:
   release:
     name: Publish release on Github and PyPI
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
 
@@ -22,16 +24,16 @@ jobs:
       - name: Build
         run: poetry build
 
-      # - name: Create github release
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     tag_name: ${{ github.ref_name }}
-      #     name: Release ${{ github.ref_name }}
-      #     prerelease: false
-      #     draft: true
-      #     files: |
-      #       dist/isn_tractor-*.tar.gz
-      #       dist/isn_tractor-*-py3-none-any.whl
+      - name: Create github release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          prerelease: false
+          draft: true
+          files: |
+            dist/isn_tractor-*.tar.gz
+            dist/isn_tractor-*-py3-none-any.whl
 
       - name: Publish to PyPI
         run: poetry publish -u ${{ secrets.PYPI_USER }} -p ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Workaround [this](https://github.com/softprops/action-gh-release/issues/236) bug in softprops/action-gh-release by giving the GITHUB_TOKEN write permissions for the repository. Documentation [here](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs).