### PR TITLE
[PART 1] The impute function could accept a function to replace missing data

### DIFF
--- a/isn_tractor/ibisn.py
+++ b/isn_tractor/ibisn.py
@@ -108,7 +108,7 @@ def impute_chunked(
     """
     column_index = snps.columns.tolist()
     chunk_idx = np.array_split(np.arange(snps.shape[1]), chunks)
-    collected = [impute(snps.iloc[:, idx]) for idx in chunk_idx]
+    collected = [impute(snps.iloc[:, idx], replace) for idx in chunk_idx]
     snps_imputed = pd.concat(collected, axis=1).reindex(columns=column_index)
     snps_imputed.columns = column_index
     return snps_imputed

--- a/isn_tractor/ibisn.py
+++ b/isn_tractor/ibisn.py
@@ -3,7 +3,7 @@ Interactome based Individual Specific Networks (Ib-ISN)
 
 Copyright 2023 Giada Lalli
 """
-from typing import Union, Literal, Tuple, List, Optional, Any, Callable
+from typing import Union, Literal, Tuple, List, Any, Callable
 import pandas as pd
 import numpy as np
 import allel


### PR DESCRIPTION
Rather than defining custom impute functions every time we want to change the replacement behaviour, the impute function can accept a custom (user defined) replacement function. This allows impute() to be very simple and also very flexible. To maintain the original behaviour, I've defined a default replacement
function (mode_genotype). I've also defined a mean_genotype() function as a replacement function that can be passed to impute() to achieve the same behaviour as impute_gene (which this commit removes). I've also changed the signature of impute_chunked to match impute.