### PR TITLE
Improve the performance (memory and CPU) of `dense_isn()`

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -25,8 +25,50 @@ def continuous(n_individuals: int, m_genes: int) -> DataFrame:
 if __name__ == "__main__":
     runner = pyperf.Runner()
 
-    bench = runner.timeit(
-        "dense",
-        stmt="dense_isn(df)",
-        setup="from benchmark import continuous; from isn_tractor.ibisn import dense_isn; df = continuous(200, 1000)",
+    runner.timeit(
+        "dense_500_1000",
+        stmt="for isn in dense_isn(df): del isn",
+        setup="from benchmark import continuous; from isn_tractor.ibisn import dense_isn; df = continuous(500, 1000)",
+    )
+
+    runner.timeit(
+        "dense_500_2000",
+        stmt="for isn in dense_isn(df): del isn",
+        setup="from benchmark import continuous; from isn_tractor.ibisn import dense_isn; df = continuous(500, 2000)",
+    )
+
+    runner.timeit(
+        "dense_500_3000",
+        stmt="for isn in dense_isn(df): del isn",
+        setup="from benchmark import continuous; from isn_tractor.ibisn import dense_isn; df = continuous(500, 3000)",
+    )
+
+    runner.timeit(
+        "dense_1000_3000",
+        stmt="for isn in dense_isn(df): del isn",
+        setup="from benchmark import continuous; from isn_tractor.ibisn import dense_isn; df = continuous(1000, 3000)",
+    )
+
+    runner.timeit(
+        "dense_2000_3000",
+        stmt="for isn in dense_isn(df): del isn",
+        setup="from benchmark import continuous; from isn_tractor.ibisn import dense_isn; df = continuous(2000, 3000)",
+    )
+
+    runner.timeit(
+        "dense_2000_5000",
+        stmt="for isn in dense_isn(df): del isn",
+        setup="from benchmark import continuous; from isn_tractor.ibisn import dense_isn; df = continuous(2000, 5000)",
+    )
+
+    runner.timeit(
+        "dense_2000_10000",
+        stmt="for isn in dense_isn(df): del isn",
+        setup="from benchmark import continuous; from isn_tractor.ibisn import dense_isn; df = continuous(2000, 10_000)",
+    )
+
+    runner.timeit(
+        "dense_5000_10000",
+        stmt="for isn in dense_isn(df): del isn",
+        setup="from benchmark import continuous; from isn_tractor.ibisn import dense_isn; df = continuous(5000, 10_000)",
     )

--- a/profile.py
+++ b/profile.py
@@ -3,16 +3,28 @@ from torch.profiler import profile, record_function, ProfilerActivity
 import isn_tractor.ibisn as it
 from benchmark import continuous
 
-df = continuous(200, 1000)
+df = continuous(500, 1500)
 
 with profile(
-    activities=[ProfilerActivity.CPU], record_shapes=True, profile_memory=True
+    activities=[ProfilerActivity.CPU],
+    record_shapes=True,
+    profile_memory=True,
+    with_stack=True,
 ) as prof:
-    it.dense_isn(df)
+    for isn in it.dense_isn(df):
+        del isn
 
 print(
     prof.key_averages(group_by_input_shape=True).table(
-        sort_by="cpu_time_total", row_limit=10
+        sort_by="cpu_time_total", row_limit=25
     )
 )
-print(prof.key_averages().table(sort_by="cpu_memory_usage", row_limit=10))
+print(
+    prof.key_averages(group_by_input_shape=True).table(
+        sort_by="cpu_memory_usage", row_limit=25
+    )
+)
+
+prof.export_chrome_trace("profiling_trace.json")
+
+prof.export_stacks("profiler_stacks.txt", "self_cpu_time_total")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ build-backend = "poetry.core.masonry.api"
 ignore_missing_imports = true
 
 [tool.pylint]
-generated-members = "t.tensor,t.matmul,t.arange,t.corrcoef,t.cat,t.argsort,t.zeros,t.device,t.square,t.from_numpy,t.mean,t.stack,t.max,t.sum,t.pow,t.sqrt,t.outer,t.flatten"
+generated-members = "t.tensor,t.matmul,t.arange,t.corrcoef,t.cat,t.argsort,t.zeros,t.device,t.square,t.from_numpy,t.mean,t.stack,t.max,t.sum,t.pow,t.sqrt,t.outer,t.flatten,t.float32,t.transpose,t.reshape"
 
 [tool.pytest.ini_options]
 markers = [

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -14,7 +14,12 @@ def continuous(n_individuals: int, m_genes: int) -> DataFrame:
     )
 
 
+def compute_dense_isn(data):
+    for isn in dense_isn(data):
+        del isn
+
+
 @pytest.mark.benchmark
 def test_dense_isn(benchmark):
     data = continuous(200, 1000)
-    benchmark.pedantic(dense_isn, args=(data,), rounds=20, iterations=3)
+    benchmark.pedantic(compute_dense_isn, args=(data,), rounds=20, iterations=3)

--- a/test/test_snp_isns.py
+++ b/test/test_snp_isns.py
@@ -1,7 +1,7 @@
 import pytest
 from isn_tractor.ibisn import sparse_isn, dense_isn, __spearman_metric
 
-from numpy import array, zeros, concatenate, corrcoef, int64, float64
+from numpy import array, zeros, concatenate, corrcoef, int64, float32
 import pandas as pd
 from pandas.testing import assert_frame_equal
 from sklearn.metrics import normalized_mutual_info_score as mutual_info
@@ -547,37 +547,62 @@ def test_dense():
         columns=["gene1", "gene2", "gene3"],
     )
 
+    out_columns = [
+        "gene1_gene1",
+        "gene1_gene2",
+        "gene1_gene3",
+        "gene2_gene1",
+        "gene2_gene2",
+        "gene2_gene3",
+        "gene3_gene1",
+        "gene3_gene2",
+        "gene3_gene3",
+    ]
+
     expected = pd.DataFrame(
         [
             (
                 1.0,
-                -3.902325,
+                -3.9023278,
                 -2.543286,
-                -3.902325,
+                -3.9023278,
                 1.0,
                 0.625879,
                 -2.543286,
                 0.625879,
                 1.0,
             ),
-            (1.0, 0.097675, 1.456714, 0.097675, 1.0, 0.625879, 1.456714, 0.625879, 1.0),
-            (1.0, 0.097675, 1.456714, 0.097675, 1.0, 0.625879, 1.456714, 0.625879, 1.0),
+            (
+                1.0,
+                0.0976758,
+                1.456714,
+                0.0976758,
+                1.0,
+                0.625879,
+                1.456714,
+                0.625879,
+                1.0,
+            ),
+            (
+                1.0,
+                0.09767747,
+                1.456714,
+                0.09767747,
+                1.0,
+                0.625879,
+                1.456714,
+                0.625879,
+                1.0,
+            ),
         ],
-        columns=[
-            "gene1_gene1",
-            "gene1_gene2",
-            "gene1_gene3",
-            "gene2_gene1",
-            "gene2_gene2",
-            "gene2_gene3",
-            "gene3_gene1",
-            "gene3_gene2",
-            "gene3_gene3",
-        ],
+        columns=out_columns,
     )
 
     for x in expected.columns:
-        expected[x] = expected[x].astype(float64)
+        expected[x] = expected[x].astype(float32)
 
-    new = dense_isn(gene_data.copy())
+    new = pd.DataFrame(
+        [network.numpy().astype(float32) for network in dense_isn(gene_data.copy())],
+        columns=out_columns,
+    )
     assert_frame_equal(expected, new)

--- a/test/test_snp_isns.py
+++ b/test/test_snp_isns.py
@@ -605,4 +605,4 @@ def test_dense():
         [network.numpy().astype(float32) for network in dense_isn(gene_data.copy())],
         columns=out_columns,
     )
-    assert_frame_equal(expected, new)
+    assert_frame_equal(expected, new, rtol=0.00001, atol=0.00001)


### PR DESCRIPTION
* Change interface to a generator: compute 1 isn (row) at a time. This reduces memory usage copying everything into a single matrix at the end.

* Do not copy input parameters (at least when running on CPU). Instead, use the same memory for the tensors as the input pandas dataframe. The transpose is just a "view" on that data too.

* Replace outer() product with a reshape() "view" and then multiply. This allows the entire ISN row computation to be computed in a single kernel.

* Use float32 types instead of float64 to reduce memory usage.